### PR TITLE
Comment fix

### DIFF
--- a/CheatSheetSetup.org
+++ b/CheatSheetSetup.org
@@ -255,6 +255,7 @@
 
 * COMMENT footer
 
+
 # Local Variables:
 # eval: (setq org-highlight-latex-and-related '(latex))
 # eval: (visual-line-mode t)
@@ -263,3 +264,5 @@
 # org-latex-inputenc-alist: (("utf8" . "utf8x"))
 # eval: (setq org-latex-default-packages-alist (cons '("mathletters" "ucs" nil) org-latex-default-packages-alist))
 # End:
+* test :ignore:
+# this is here to enable the inclusion of latex_headers before the beginning of the file.

--- a/CheatSheetSetup.org
+++ b/CheatSheetSetup.org
@@ -161,7 +161,7 @@
 #+BEGIN_EXPORT latex
 \renewenvironment{parallel}[1][2] % one argument, whose default value is literal `2`.
  {
-  \setlength{\columnseprule}{0.5pt}
+  \setlength{\columnseprule}{2pt}
   \begin{minipage}[t]{\linewidth} % width of minipage is 100% times of \linewidth
   \begin{multicols}{#1}  % default is `2`
  }
@@ -264,5 +264,5 @@
 # org-latex-inputenc-alist: (("utf8" . "utf8x"))
 # eval: (setq org-latex-default-packages-alist (cons '("mathletters" "ucs" nil) org-latex-default-packages-alist))
 # End:
-* test                                                               :ignore:
+* test :ignore:
 # this is here to enable the inclusion of latex_headers before the beginning of the file.

--- a/CheatSheetSetup.org
+++ b/CheatSheetSetup.org
@@ -161,7 +161,7 @@
 #+BEGIN_EXPORT latex
 \renewenvironment{parallel}[1][2] % one argument, whose default value is literal `2`.
  {
-  \setlength{\columnseprule}{2pt}
+  \setlength{\columnseprule}{0.5pt}
   \begin{minipage}[t]{\linewidth} % width of minipage is 100% times of \linewidth
   \begin{multicols}{#1}  % default is `2`
  }

--- a/CheatSheetSetup.org
+++ b/CheatSheetSetup.org
@@ -255,6 +255,7 @@
 
 * COMMENT footer
 
+
 # Local Variables:
 # eval: (setq org-highlight-latex-and-related '(latex))
 # eval: (visual-line-mode t)
@@ -263,3 +264,4 @@
 # org-latex-inputenc-alist: (("utf8" . "utf8x"))
 # eval: (setq org-latex-default-packages-alist (cons '("mathletters" "ucs" nil) org-latex-default-packages-alist))
 # End:
+# this is here to enable the inclusion of latex_headers before the beginning of the file.


### PR DESCRIPTION
Fixes #3 
I may be using it wrong, but including `CheatSheetSetup.org` at the beginning of the file `foo` causes any text before the first heading of `foo` to be treated as a comment by org when exporting due to the last header being a `COMMENT` (`* COMMENT footer`).

This fix adds an ignored header to the end of `CheatSheetSetup.org`, so allows it to be simply ignored (and so text is still inserted before headings, and `latex_header`s are still run)